### PR TITLE
Draft: Patch fstab on Cygwin 

### DIFF
--- a/packages/setup-ocaml/src/installer.ts
+++ b/packages/setup-ocaml/src/installer.ts
@@ -31,7 +31,7 @@ import {
 } from "./opam.js";
 import { retrieveOpamLocalPackages } from "./packages.js";
 import { resolvedCompiler } from "./version.js";
-import { setupCygwin } from "./windows.js";
+import { fixFstab, setupCygwin } from "./windows.js";
 
 export async function installer() {
   if (core.isDebug()) {
@@ -70,6 +70,7 @@ export async function installer() {
     }
     await fs.writeFile(CYGWIN_BASH_ENV, "set -o igncr");
     core.exportVariable("BASH_ENV", CYGWIN_BASH_ENV);
+    await fixFstab();
     core.addPath(CYGWIN_ROOT_BIN);
   }
   await setupOpam();


### PR DESCRIPTION
To be able to install `ocamlfind.1.9.8`, we'd need this fix. Currently, the builds pass successfully because of the cached opam directory which already has `ocamlfind.1.9.8` installed.  See https://github.com/ocaml/setup-ocaml/pull/975

I'm not sure what the plan for keeping this repo up-to-date with `ocaml/setup-ocaml` is, but having this fix would be helpful!
