### PR TITLE
fix(windows): reduce Cygwin homepage fragility

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -151431,19 +151431,22 @@ async function getCygwinVersion() {
   const response = await httpClient.get("https://www.cygwin.com");
   const body = await response.readBody();
   const $2 = load(body);
-  let version = "";
+  let version = null;
   $2("a").each((_index, element) => {
     const text3 = $2(element).text();
     if (semver3.valid(text3) === text3) {
       version = text3;
     }
   });
-  return version;
+  if (version !== null) {
+    return version;
+  } else {
+    throw new Error("Couldn't parse Cygwin version from homepage");
+  }
 }
 async function setupCygwin() {
   await core4.group("Setting up Cygwin environment", async () => {
-    const version = await getCygwinVersion();
-    const cachedPath = toolCache2.find("cygwin", version, "x86_64");
+    const cachedPath = toolCache2.find("cygwin", "latest", "x86_64");
     if (cachedPath === "") {
       const downloadedPath = await toolCache2.downloadTool(
         "https://cygwin.com/setup-x86_64.exe"
@@ -151452,7 +151455,7 @@ async function setupCygwin() {
         downloadedPath,
         "setup-x86_64.exe",
         "cygwin",
-        version,
+        "latest",
         "x86_64"
       );
       core4.addPath(cachedPath2);

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -151441,6 +151441,8 @@ async function getCygwinVersion() {
   if (version !== null) {
     return version;
   } else {
+    core4.info("Cygwin homepage:");
+    core4.info(body);
     throw new Error("Couldn't parse Cygwin version from homepage");
   }
 }

--- a/packages/setup-ocaml/src/windows.ts
+++ b/packages/setup-ocaml/src/windows.ts
@@ -26,20 +26,23 @@ export async function getCygwinVersion() {
   const response = await httpClient.get("https://www.cygwin.com");
   const body = await response.readBody();
   const $ = cheerio.load(body);
-  let version = "";
+  let version = null;
   $("a").each((_index, element) => {
     const text = $(element).text();
     if (semver.valid(text) === text) {
       version = text;
     }
   });
-  return version;
+  if (version !== null) {
+    return version;
+  } else {
+    throw new Error("Couldn't parse Cygwin version from homepage");
+  }
 }
 
 export async function setupCygwin() {
   await core.group("Setting up Cygwin environment", async () => {
-    const version = await getCygwinVersion();
-    const cachedPath = toolCache.find("cygwin", version, "x86_64");
+    const cachedPath = toolCache.find("cygwin", "latest", "x86_64");
     if (cachedPath === "") {
       const downloadedPath = await toolCache.downloadTool(
         "https://cygwin.com/setup-x86_64.exe",
@@ -48,7 +51,7 @@ export async function setupCygwin() {
         downloadedPath,
         "setup-x86_64.exe",
         "cygwin",
-        version,
+        "latest",
         "x86_64",
       );
       core.addPath(cachedPath);

--- a/packages/setup-ocaml/src/windows.ts
+++ b/packages/setup-ocaml/src/windows.ts
@@ -36,6 +36,8 @@ export async function getCygwinVersion() {
   if (version !== null) {
     return version;
   } else {
+    core.info("Cygwin homepage:");
+    core.info(body);
     throw new Error("Couldn't parse Cygwin version from homepage");
   }
 }


### PR DESCRIPTION
It seems like sometimes the Cygwin homepage does not contain its version in the format setup-ocaml expects. This causes the tool cache to complain about an empty version: https://github.com/semgrep/semgrep-proprietary/actions/runs/20381063339/job/58571399243?pr=5267 and perhaps cause higher-level caching issues too.

This PR
1. Removes the usage of the Cygwin version in the tool cache, because any later action invocations that want Cygwin from the tool cache might as well use the same version as the first. (This assumes that the tool cache is ephemeral, as is the case on GitHub-hosted runners. We are not currently concerned about self-hosted runners that have non-ephemeral tool caches set up.)
2. Explicitly throws an error when the Cygwin version cannot be identified, so that we can better track if this still occurs (for the `actions/cache` use).