### PR TITLE
chore: remove support for `ubuntu-slim` image

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-slim
           - ubuntu-latest
           - macos-latest
           - windows-latest


### PR DESCRIPTION
It seems like the upstream has abandoned `ubuntu-slim` support, maybe it'd be worth for us to do so as well as we do not use it in any of our pipelines. 