### PR TITLE
fix: pin opam to 2.5.0

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -108706,7 +108706,7 @@ async function updateUnixPackageIndexFiles() {
 
 // src/opam.ts
 var latestOpamRelease = (async () => {
-  const semverRange = ALLOW_PRERELEASE_OPAM ? "*" : "<2.6.0";
+  const semverRange = ALLOW_PRERELEASE_OPAM ? "*" : ">=2.5.0 < 2.5.1";
   const octokit = github.getOctokit(GITHUB_TOKEN, void 0, retry);
   const { data: releases } = await octokit.rest.repos.listReleases({
     owner: "ocaml",

--- a/dist/post/index.cjs
+++ b/dist/post/index.cjs
@@ -107478,7 +107478,7 @@ retry.VERSION = VERSION;
 // src/opam.ts
 var semver = __toESM(require_semver4(), 1);
 var latestOpamRelease = (async () => {
-  const semverRange = ALLOW_PRERELEASE_OPAM ? "*" : "<2.6.0";
+  const semverRange = ALLOW_PRERELEASE_OPAM ? "*" : ">=2.5.0 < 2.5.1";
   const octokit = github.getOctokit(GITHUB_TOKEN, void 0, retry);
   const { data: releases } = await octokit.rest.repos.listReleases({
     owner: "ocaml",

--- a/packages/setup-ocaml/src/opam.ts
+++ b/packages/setup-ocaml/src/opam.ts
@@ -20,7 +20,7 @@ import {
 } from "./unix.js";
 
 export const latestOpamRelease = (async () => {
-  const semverRange = ALLOW_PRERELEASE_OPAM ? "*" : "<2.6.0";
+  const semverRange = ALLOW_PRERELEASE_OPAM ? "*" : ">=2.5.0 < 2.5.1";
   const octokit = github.getOctokit(GITHUB_TOKEN, undefined, retry);
   const { data: releases } = await octokit.rest.repos.listReleases({
     owner: "ocaml",


### PR DESCRIPTION
opam 2.5.1 was released with only source tarballs and no platform builds, causing "failed to find opam binary" for _all_ OS/arch combos.